### PR TITLE
feat: add bot header

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -13,6 +13,9 @@ const (
 	// UserAgentHeader header.
 	UserAgentHeader = "User-Agent"
 
+	// DeviceBotHeader header.
+	DeviceBotHeader = "X-Device-Bot"
+
 	// DeviceMobileHeader header.
 	DeviceMobileHeader = "X-Device-Mobile"
 	// DeviceOsHeader header.
@@ -53,6 +56,8 @@ func New(ctx context.Context, next http.Handler, config *Config, name string) (h
 
 func (mw *TraefikUserAgent) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	ua := user_agent.New(req.Header.Get(UserAgentHeader))
+
+	req.Header.Set(DeviceBotHeader, strconv.FormatBool(ua.Bot()))
 
 	req.Header.Set(DeviceMobileHeader, strconv.FormatBool(ua.Mobile()))
 	req.Header.Set(DeviceOsHeader, ua.OSInfo().Name)

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -41,6 +41,8 @@ func TestParse(t *testing.T) {
 
 	instance.ServeHTTP(recorder, req)
 
+	assertHeader(t, req, mw.DeviceBotHeader, "false")
+
 	assertHeader(t, req, mw.DeviceMobileHeader, "false")
 	assertHeader(t, req, mw.DeviceOsHeader, "Linux")
 
@@ -49,6 +51,29 @@ func TestParse(t *testing.T) {
 
 	assertHeader(t, req, mw.DeviceEngineHeader, "AppleWebKit")
 	assertHeader(t, req, mw.DeviceEngineVersionHeader, "537.11")
+}
+
+func TestParseBot(t *testing.T) {
+	next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {})
+
+	instance, _ := mw.New(context.TODO(), next, mw.CreateConfig(), "traefikuseragent")
+
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "http://localhost", nil)
+	req.Header.Set(mw.UserAgentHeader, "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)")
+
+	instance.ServeHTTP(recorder, req)
+
+	assertHeader(t, req, mw.DeviceBotHeader, "true")
+
+	assertHeader(t, req, mw.DeviceMobileHeader, "false")
+	assertHeader(t, req, mw.DeviceOsHeader, "")
+
+	assertHeader(t, req, mw.DeviceBrowserHeader, "Googlebot")
+	assertHeader(t, req, mw.DeviceBrowserVersionHeader, "2.1")
+
+	assertHeader(t, req, mw.DeviceEngineHeader, "")
+	assertHeader(t, req, mw.DeviceEngineVersionHeader, "")
 }
 
 func TestParseNoHeader(t *testing.T) {
@@ -60,6 +85,8 @@ func TestParseNoHeader(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "http://localhost", nil)
 
 	instance.ServeHTTP(recorder, req)
+
+	assertHeader(t, req, mw.DeviceBotHeader, "false")
 
 	assertHeader(t, req, mw.DeviceMobileHeader, "false")
 	assertHeader(t, req, mw.DeviceOsHeader, "")
@@ -81,6 +108,8 @@ func TestParseBadFormat(t *testing.T) {
 	req.Header.Set(mw.UserAgentHeader, "123asd")
 
 	instance.ServeHTTP(recorder, req)
+
+	assertHeader(t, req, mw.DeviceBotHeader, "false")
 
 	assertHeader(t, req, mw.DeviceMobileHeader, "false")
 	assertHeader(t, req, mw.DeviceOsHeader, "")


### PR DESCRIPTION
@ievgenii-shepeliuk This PR adds the `X-Device-Bot` bot header to every request. This header contains true or false if the user-agent that makes a request is a bot or not. This makes it easier to filter out bots (when they use a proper user-agent).

This PR is not tested so make sure to test before merge!

And also: Thank you for this plugin. I really like it :D